### PR TITLE
add ability to use default credentials

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -26,6 +26,10 @@ func SQS(secret, access, url, region string, messageTimeout int) Queue {
 	})
 }
 
+func SQSNoCreds(url, region string, messageTimeout int) Queue {
+	return sqs.NewNoCreds(url, region, messageTimeout)
+}
+
 func File(path string) Queue {
 	return file.New(path)
 }

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -29,7 +29,7 @@ func New(cfg Config) SQS {
 	return instance
 }
 
-// NewUseRole returns an instance of SQS using default credentials, fall back to env...
+// NewNoCreds returns an instance of SQS using default credentials, fall back to env...
 func NewNoCreds(url, region string, timeout int) SQS {
 	awsConfig := aws.Config{}
 	awsConfig.Region = aws.String(region)

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -41,6 +41,7 @@ func NewNoCreds(url, region string, timeout int) SQS {
 		cfg: Config{
 			URL: url,
 			MessageTimeout: timeout,
+			Region: region,
 		},
 	}
 }

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -29,6 +29,22 @@ func New(cfg Config) SQS {
 	return instance
 }
 
+// NewUseRole returns an instance of SQS using default credentials, fall back to env...
+func NewNoCreds(url, region string, timeout int) SQS {
+	awsConfig := aws.Config{}
+	awsConfig.Region = aws.String(region)
+
+	session := session.New()
+	svc := sqs.New(session, &awsConfig)
+	return SQS{
+		sqsService: svc,
+		cfg: Config{
+			URL: url,
+			MessageTimeout: timeout,
+		},
+	}
+}
+
 // Next returns the next SQS message.
 func (instance SQS) Next(queue string) (messageID, result string, err error) {
 	params := &sqs.ReceiveMessageInput{


### PR DESCRIPTION
This will make it so access keys and secrets are no longer necessary if the binary is running on a machine with other credentials setup. For example, if you have ~/.aws/credentials setup on your local machine, the binary will use those. Or if the binary is running on an ec2 instance or in an ecs task and there is a role assigned to the instance the binary will use that role.

I tried to follow any patters I could see in the package. I'm open to suggestions especially when it comes to naming!